### PR TITLE
Separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ grunt.loadNpmTasks('grunt-purifycss');
 
 ## The "purifycss" task
 
+### Options
+
+#### options.separateFiles
+Type: `Boolean` Default value: `false`
+Boolean value that tells the task whether or not you want to maintain separate files for each `.css` file input
+
+#### options.prefix
+Type: `String` Default value: `pure-`
+A string value that, if you have chosen `separateFiles: true`, will prepend each new output `.css` file with a prefix 
+
 ### Usage Examples
 
 In this example, the default options are to specify a target with src files, style files, and an output destination. The plugin will search for style selectors used in the source files, and then output a trimmed down style sheet.
@@ -33,6 +43,24 @@ grunt.initConfig({
       dest: 'tmp/purestyles.css'
     },
   },
+});
+```
+
+In this example, options are set to separateFiles with a prefix.  Please note, a destination folder is still expected, but a filename should not be included.
+
+```js
+grunt.initConfig({
+  purifycss: {
+    options: {
+      separateFiles: true,
+      prefix: 'purifiedcss-'
+    },
+    target: {
+      src: ['test/fixtures/*.html', 'test/fixtures/*.js'],
+      css: ['test/fixtures/*.css'],
+      dest: 'tmp/'
+    }
+  }
 });
 ```
 

--- a/tasks/purifycss.js
+++ b/tasks/purifycss.js
@@ -10,13 +10,35 @@
 
 var glob = require('glob');
 var purify = require('purify-css');
+var path = require('path');
 
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('purifycss', 'Clean unnecessary CSS', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
+        separateFiles: false,
+        prefix: 'pure-'
     });
+
+    var createOutput = function(srcFiles, css, dest) {
+      var destFile = '',
+          styles = css;
+      if (!Array.isArray(css)) styles = [css];
+
+      var pure = purify(srcFiles, styles, {write: false, info: true});
+
+      var ext = path.extname(dest);
+      //if the path has an extension, then use that as the destination file
+      if (ext) {
+          destFile = dest;
+      } else {
+          destFile = dest + '/' + options.prefix + path.basename(css); 
+      }
+
+      grunt.file.write(path.normalize(destFile), pure);
+      grunt.log.writeln('File "' + path.normalize(destFile) + '" created.');
+    }
 
     var src = [];
     this.data.src.forEach(function(pathPattern) {
@@ -32,10 +54,16 @@ module.exports = function(grunt) {
       styles = styles.concat(style);
     });
 
-    var pure = purify(src, styles, {write: false, info: true});
-
-    grunt.file.write(this.data.dest, pure);
-    grunt.log.writeln('File "' + this.data.dest + '" created.');
+    var dest = this.data.dest;
+    if (options.separateFiles) {
+        styles.forEach(function(style) {
+            createOutput(src, style, dest);
+        });
+    } else {
+        createOutput(src, styles, dest);
+    }
   });
 
 };
+
+


### PR DESCRIPTION
This pull request does the following:
- Allows the user to not have to concatenate all the css into one file, but continue to have separate files
  - Use case here: may want to have separate files for dynamic loading, separation for certain media (i.e. print).

Added the following:
- Options:
  - separateFiles -- boolean
  - prefix for files should separateFiles be chosen so as to not overwrite originals

Thanks and let me know.

Richard
