### PR TITLE
Bug Fix for undefined

### DIFF
--- a/tasks/purifycss.js
+++ b/tasks/purifycss.js
@@ -19,14 +19,14 @@ module.exports = function(grunt) {
     });
 
     var src = [];
-    this.data.src.forEach(function(pathPattern) {
+    this.data.target.src.forEach(function(pathPattern) {
       var files = glob.sync(pathPattern);
       console.log("Source Files: ", files);
       src = src.concat(files);
     });
 
     var styles = [];
-    this.data.css.forEach(function(pathPattern) {
+    this.data.target.css.forEach(function(pathPattern) {
       var style = glob.sync(pathPattern);
       console.log("Style Files: ", style);
       styles = styles.concat(style);
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
 
     var pure = purify(src, styles, {write: false, info: true});
 
-    grunt.file.write(this.data.dest, pure);
+    grunt.file.write(this.data.target.dest, pure);
     grunt.log.writeln('File "' + this.data.dest + '" created.');
   });
 


### PR DESCRIPTION
I would get 

```
   Warning: Cannot read property 'forEach' of undefined Use --force to continue.  
   TypeError: Cannot read property 'forEach' of undefined
    at Object.<anonymous> (/node_modules/grunt-purifycss/tasks/purifycss.js:22:18)
   .
   .
```

and then the task would stop

looking at the grunt API I noticed that data simply returns the object value I passed in my config
which if according to the example is inside data.target not the data object itself

using grunt 0.4.5 (but I got that from the latest documentation for the API
