### PR TITLE
Correctly pass options object

### DIFF
--- a/tasks/purifycss.js
+++ b/tasks/purifycss.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       styles = styles.concat(style);
     });
 
-    var pure = purify(src, styles, {write: false, info: true});
+    var pure = purify(src, styles, options);
 
     grunt.file.write(this.data.dest, pure);
     grunt.log.writeln('File "' + this.data.dest + '" created.');


### PR DESCRIPTION
This is a fix for this bug https://github.com/purifycss/grunt-purifycss/issues/7
